### PR TITLE
Minor wasm-vips improvements

### DIFF
--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -46,21 +46,24 @@ export async function convertImageToJpeg( file: File ) {
  */
 export async function resizeImage( file: File, resize: ImageSizeCrop ) {
 	const vips = await getVips();
-	let image = vips.Image.newFromBuffer( await file.arrayBuffer() );
-
-	const { width, height } = image;
-
 	const options: Record< string, unknown > = {};
 	if ( resize.height ) {
 		options.height = resize.height;
 	}
-
-	if ( ! resize.crop ) {
-		image = image.thumbnailImage( resize.width, options );
-	} else if ( true === resize.crop ) {
+	if ( true === resize.crop ) {
 		options.crop = 'centre';
-		image = image.thumbnailImage( resize.width, options );
+	}
+
+	let image;
+
+	if ( ! resize.crop || true === resize.crop ) {
+		image = vips.Image.thumbnailBuffer( await file.arrayBuffer(),
+			resize.width, options );
 	} else {
+		image = vips.Image.newFromBuffer( await file.arrayBuffer() );
+
+		const { width, height } = image;
+
 		let left = 0;
 		if ( 'center' === resize.crop[ 0 ] ) {
 			left = width / 2;

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -6,7 +6,7 @@ import {
 
 import type { ImageSizeCrop } from './types';
 
-let cleanup = () => void 0;
+let cleanup: () => void;
 
 async function getVips() {
 	return window.Vips( {
@@ -35,7 +35,7 @@ export async function convertImageToJpeg( file: File ) {
 	const vips = await getVips();
 	const image = vips.Image.newFromBuffer( await file.arrayBuffer() );
 	const outBuffer = image.writeToBuffer( '.jpeg', { Q: 75 } );
-	cleanup();
+	cleanup?.();
 
 	const fileName = `${ getFileBasename( file.name ) }.jpeg`;
 	return blobToFile(
@@ -91,7 +91,7 @@ export async function resizeImage( file: File, resize: ImageSizeCrop ) {
 
 	const ext = getExtensionFromMimeType( file.type );
 	const outBuffer = image.writeToBuffer( `.${ ext }` );
-	cleanup();
+	cleanup?.();
 
 	const fileName = `${ getFileBasename( file.name ) }-${ image.width }x${
 		image.height

--- a/packages/vips/src/test/resizeImage.ts
+++ b/packages/vips/src/test/resizeImage.ts
@@ -3,11 +3,9 @@ import type { ImageSizeCrop } from '../types';
 
 let windowSpy: any;
 const mockImage: any = {
-	thumbnailImage: jest.fn( () => mockImage ),
-	crop: jest.fn( () => mockImage ),
 	writeToBuffer: jest.fn(),
 };
-const mockThumbnailImage = jest.fn( () => mockImage );
+const mockThumbnailBuffer = jest.fn( () => mockImage );
 const mockCrop = jest.fn( () => mockImage );
 
 describe( 'resizeImage', () => {
@@ -17,12 +15,12 @@ describe( 'resizeImage', () => {
 			Vips: jest.fn( () => ( {
 				Image: {
 					newFromBuffer: jest.fn( () => ( {
-						thumbnailImage: mockThumbnailImage,
 						crop: mockCrop,
 						writeToBuffer: jest.fn(),
 						width: 100,
 						height: 100,
 					} ) ),
+					thumbnailBuffer: mockThumbnailBuffer,
 				},
 			} ) ),
 		} ) );
@@ -34,17 +32,18 @@ describe( 'resizeImage', () => {
 	} );
 
 	it( 'resizes without crop', async () => {
-		const jpegFile = new File( [], 'example.jpg', {
+		const jpegFile = new File( [ '<BLOB>' ], 'example.jpg', {
 			lastModified: 1234567891,
 			type: 'image/jpeg',
 		} );
+		const buffer = await jpegFile.arrayBuffer();
 
 		await resizeImage( jpegFile, {
 			width: 100,
 			height: 100,
 		} );
 
-		expect( mockThumbnailImage ).toHaveBeenCalledWith( 100, {
+		expect( mockThumbnailBuffer ).toHaveBeenCalledWith( buffer, 100, {
 			height: 100,
 		} );
 		expect( mockCrop ).not.toHaveBeenCalled();
@@ -55,21 +54,23 @@ describe( 'resizeImage', () => {
 			lastModified: 1234567891,
 			type: 'image/jpeg',
 		} );
+		const buffer = await jpegFile.arrayBuffer();
 
 		await resizeImage( jpegFile, {
 			width: 100,
 			height: 0,
 		} );
 
-		expect( mockThumbnailImage ).toHaveBeenCalledWith( 100, {} );
+		expect( mockThumbnailBuffer ).toHaveBeenCalledWith( buffer, 100, {} );
 		expect( mockCrop ).not.toHaveBeenCalled();
 	} );
 
 	it( 'resizes with center crop', async () => {
-		const jpegFile = new File( [], 'example.jpg', {
+		const jpegFile = new File( [ '<BLOB>' ], 'example.jpg', {
 			lastModified: 1234567891,
 			type: 'image/jpeg',
 		} );
+		const buffer = await jpegFile.arrayBuffer();
 
 		await resizeImage( jpegFile, {
 			width: 100,
@@ -77,17 +78,18 @@ describe( 'resizeImage', () => {
 			crop: true,
 		} );
 
-		expect( mockThumbnailImage ).toHaveBeenCalledWith( 100, {
+		expect( mockThumbnailBuffer ).toHaveBeenCalledWith( buffer, 100, {
 			height: 100,
 			crop: 'centre',
 		} );
 		expect( mockCrop ).not.toHaveBeenCalled();
 	} );
 	it( 'resizes with center crop and zero height', async () => {
-		const jpegFile = new File( [], 'example.jpg', {
+		const jpegFile = new File( [ '<BLOB>' ], 'example.jpg', {
 			lastModified: 1234567891,
 			type: 'image/jpeg',
 		} );
+		const buffer = await jpegFile.arrayBuffer();
 
 		await resizeImage( jpegFile, {
 			width: 100,
@@ -95,7 +97,7 @@ describe( 'resizeImage', () => {
 			crop: true,
 		} );
 
-		expect( mockThumbnailImage ).toHaveBeenCalledWith( 100, {
+		expect( mockThumbnailBuffer ).toHaveBeenCalledWith( buffer, 100, {
 			crop: 'centre',
 		} );
 		expect( mockCrop ).not.toHaveBeenCalled();
@@ -141,7 +143,7 @@ describe( 'resizeImage', () => {
 			],
 		]
 	)( 'resizes with %s param and crops %s', async ( crop, expected ) => {
-		const jpegFile = new File( [], 'example.jpg', {
+		const jpegFile = new File( [ '<BLOB>' ], 'example.jpg', {
 			lastModified: 1234567891,
 			type: 'image/jpeg',
 		} );


### PR DESCRIPTION
Hi @swissspidy,

Thanks for using wasm-vips! This PR includes some minor improvements to its usage:
- Avoid use of `thumbnailImage` (see https://libvips.org/API/current/libvips-resample.html#vips-thumbnail-image).
- Ensure every image instance that is returned from wasm-vips is properly cleaned-up (see https://github.com/kleisauke/wasm-vips/issues/13#issuecomment-1073246828).