### PR TITLE
Move vips to web worker

### DIFF
--- a/packages/upload-media/src/store/actions.ts
+++ b/packages/upload-media/src/store/actions.ts
@@ -1319,7 +1319,6 @@ export function resizeCropItem( id: QueueItemId ) {
 			const file = await vipsResizeImage( item.file, item.resize );
 			dispatch.finishTranscoding( id, file );
 		} catch ( error ) {
-			console.log( error );
 			dispatch.cancelItem(
 				id,
 				error instanceof Error

--- a/packages/upload-media/src/store/actions.ts
+++ b/packages/upload-media/src/store/actions.ts
@@ -5,7 +5,12 @@ import { createBlobURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import type { WPDataRegistry } from '@wordpress/data/build-types/registry';
 import { store as preferencesStore } from '@wordpress/preferences';
 
-import { getFileBasename, getMediaTypeFromMimeType } from '@mexp/media-utils';
+import {
+	getFileBasename,
+	getMediaTypeFromMimeType,
+	blobToFile,
+	getExtensionFromMimeType,
+} from '@mexp/media-utils';
 
 import { UploadError } from '../uploadError';
 import {
@@ -67,6 +72,11 @@ const createBlurhashWorker = createWorkerFactory(
 		)
 );
 const blurhashWorker = createBlurhashWorker();
+
+const createVipsWorker = createWorkerFactory(
+	() => import( /* webpackChunkName: 'vips' */ '@mexp/vips' )
+);
+const vipsWorker = createVipsWorker();
 
 // Safari does not currently support WebP in HTMLCanvasElement.toBlob()
 // See https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob
@@ -935,6 +945,61 @@ export function maybeTranscodeItem( id: QueueItemId ) {
 	};
 }
 
+async function vipsConvertImageFormat(
+	file: File,
+	type:
+		| 'image/jpeg'
+		| 'image/png'
+		| 'image/webp'
+		| 'image/avif'
+		| 'image/gif',
+	quality: number
+) {
+	const buffer = await vipsWorker.convertImageFormat(
+		await file.arrayBuffer(),
+		type,
+		quality
+	);
+	const ext = getExtensionFromMimeType( type );
+	const fileName = `${ getFileBasename( file.name ) }.${ ext }`;
+	return blobToFile( new Blob( [ buffer ], { type } ), fileName, type );
+}
+
+async function vipsCompressImage( file: File, quality: number ) {
+	const buffer = await vipsWorker.compressImage(
+		await file.arrayBuffer(),
+		file.type,
+		quality
+	);
+	return blobToFile(
+		new Blob( [ buffer ], { type: file.type } ),
+		file.name,
+		file.type
+	);
+}
+async function vipsResizeImage( file: File, resize: ImageSizeCrop ) {
+	const ext = getExtensionFromMimeType( file.type );
+
+	if ( ! ext ) {
+		throw new Error( 'Unsupported file type' );
+	}
+
+	const { buffer, width, height } = await vipsWorker.resizeImage(
+		await file.arrayBuffer(),
+		ext,
+		resize
+	);
+	const fileName = `${ getFileBasename(
+		file.name
+	) }-${ width }x${ height }.${ ext }`;
+
+	return blobToFile(
+		new Blob( [ buffer ], { type: file.type } ),
+		fileName,
+		file.type
+	);
+}
+
 export function optimizeImageItem(
 	id: QueueItemId,
 	requireApproval: boolean = false
@@ -982,10 +1047,6 @@ export function optimizeImageItem(
 							imageQuality / 100
 						);
 					} else {
-						const { compressImage: vipsCompressImage } =
-							await import(
-								/* webpackChunkName: 'vips' */ '@mexp/vips'
-							);
 						file = await vipsCompressImage(
 							item.file,
 							imageQuality / 100
@@ -1000,10 +1061,6 @@ export function optimizeImageItem(
 							imageQuality / 100
 						);
 					} else {
-						const { convertImageFormat: vipsConvertImageFormat } =
-							await import(
-								/* webpackChunkName: 'vips' */ '@mexp/vips'
-							);
 						file = await vipsConvertImageFormat(
 							item.file,
 							'image/webp',
@@ -1012,12 +1069,7 @@ export function optimizeImageItem(
 					}
 					break;
 				case 'avif':
-					const { convertImageFormat: vipsConvertImageFormat } =
-						await import(
-							/* webpackChunkName: 'vips' */ '@mexp/vips'
-						);
-
-					// No browsers support AVIF in HTMLCanvasElement.toBlob() yet.
+					// No browsers support AVIF in HTMLCanvasElement.toBlob() yet, so always use vips.
 					// See https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob
 					file = await vipsConvertImageFormat(
 						item.file,
@@ -1034,11 +1086,6 @@ export function optimizeImageItem(
 							imageQuality / 100
 						);
 					} else {
-						// eslint-disable-next-line @typescript-eslint/no-shadow
-						const { convertImageFormat: vipsConvertImageFormat } =
-							await import(
-								/* webpackChunkName: 'vips' */ '@mexp/vips'
-							);
 						file = await vipsConvertImageFormat(
 							item.file,
 							'image/jpeg',
@@ -1269,12 +1316,10 @@ export function resizeCropItem( id: QueueItemId ) {
 		dispatch.startTranscoding( id );
 
 		try {
-			const { resizeImage: vipsResizeImage } = await import(
-				/* webpackChunkName: 'vips' */ '@mexp/vips'
-			);
 			const file = await vipsResizeImage( item.file, item.resize );
 			dispatch.finishTranscoding( id, file );
 		} catch ( error ) {
+			console.log( error );
 			dispatch.cancelItem(
 				id,
 				error instanceof Error

--- a/packages/upload-media/src/workers/vips.worker.ts
+++ b/packages/upload-media/src/workers/vips.worker.ts
@@ -1,0 +1,48 @@
+import * as vips from '@mexp/vips';
+
+import type { ImageSizeCrop } from '../store/types';
+
+/**
+ * Converts an image to a specific format.
+ *
+ * @param buffer  Image.
+ * @param type    Mime type.
+ * @param quality Image quality.
+ * @return New image.
+ */
+export async function convertImageFormat(
+	buffer: ArrayBuffer,
+	type:
+		| 'image/jpeg'
+		| 'image/png'
+		| 'image/webp'
+		| 'image/avif'
+		| 'image/gif',
+	quality = 0.82
+) {
+	return vips.convertImageFormat( buffer, type, quality );
+}
+
+export async function compressImage(
+	buffer: ArrayBuffer,
+	type: string,
+	quality = 0.82
+) {
+	return vips.compressImage( buffer, type, quality );
+}
+
+/**
+ * Resizes an image using vips.
+ *
+ * @param buffer File buffer.
+ * @param ext    File extension.
+ * @param resize
+ * @return Processed file object.
+ */
+export async function resizeImage(
+	buffer: ArrayBuffer,
+	ext: string,
+	resize: ImageSizeCrop
+) {
+	return vips.resizeImage( buffer, ext, resize );
+}

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -1,12 +1,15 @@
-import type Vips from 'wasm-vips';
+// const Vips = require( 'wasm-vips' );
+// import type Vips from 'wasm-vips';
+const Vips = require( 'wasm-vips' );
 
-import {
-	blobToFile,
-	getExtensionFromMimeType,
-	getFileBasename,
-} from '@mexp/media-utils';
+import { getExtensionFromMimeType } from '@mexp/media-utils';
 
 import type { ImageSizeCrop, ThumbnailOptions } from './types';
+
+type EmscriptenModule = {
+	setAutoDeleteLater: ( autoDelete: boolean ) => void;
+	setDelayFunction: ( fn: ( fn: () => void ) => void ) => void;
+};
 
 let cleanup: () => void;
 
@@ -17,14 +20,32 @@ async function getVips() {
 		return vipsInstance;
 	}
 
-	vipsInstance = await window.Vips( {
+	console.log( globalThis.importScripts );
+
+	globalThis.importScripts(
+		'https://cdn.jsdelivr.net/npm/wasm-vips@0.0.7/lib/vips.js'
+	);
+
+	console.log( globalThis.Vips );
+
+	vipsInstance = await Vips( {
+		// locateFile: ( fileName: string ) =>
+		// 	`https://cdn.jsdelivr.net/npm/wasm-vips@0.0.7/lib/${ fileName }`,
+		locateFile: ( fileName, scriptDirectory ) => {
+			console.log('locateFile', fileName, scriptDirectory);
+			return `https://cdn.jsdelivr.net/npm/wasm-vips@0.0.7/lib/${ fileName }`;
+			return scriptDirectory + fileName;
+		},
+		mainScriptUrlOrBlob:
+			'https://cdn.jsdelivr.net/npm/wasm-vips@0.0.7/lib/vips-es6.js',
+		// mainScriptUrlOrBlob: 'https://cdn.jsdelivr.net/npm/wasm-vips@0.0.7/lib/vips.js',
 		// https://github.com/kleisauke/wasm-vips/issues/12#issuecomment-1067001784
 		// https://github.com/kleisauke/wasm-vips/blob/789363e5b54d677b109bcdaf8353d283d81a8ee3/src/locatefile-cors-pre.js#L4
 		// @ts-ignore
 		workaroundCors: true,
 		// locateFile: ( file ) =>
 		// 	`https://cdn.jsdelivr.net/npm/wasm-vips@0.0.7/lib/${ file }`,
-		preRun: ( module ) => {
+		preRun: ( module: EmscriptenModule ) => {
 			// https://github.com/kleisauke/wasm-vips/issues/13#issuecomment-1073246828
 			module.setAutoDeleteLater( true );
 			module.setDelayFunction( ( fn: () => void ) => ( cleanup = fn ) );
@@ -35,7 +56,7 @@ async function getVips() {
 }
 
 export async function convertImageFormat(
-	file: File,
+	buffer: ArrayBuffer,
 	type:
 		| 'image/jpeg'
 		| 'image/png'
@@ -45,15 +66,17 @@ export async function convertImageFormat(
 	quality = 0.82
 ) {
 	const ext = getExtensionFromMimeType( type );
+
+	if ( ! ext ) {
+		throw new Error( 'Unsupported file type' );
+	}
+
 	const vips = await getVips();
-	const image = vips.Image.newFromBuffer(
-		new Uint8Array( await file.arrayBuffer() )
-	);
+	const image = vips.Image.newFromBuffer( new Uint8Array( buffer ) );
 	const outBuffer = image.writeToBuffer( `.${ ext }`, { Q: quality * 100 } );
 	cleanup?.();
 
-	const fileName = `${ getFileBasename( file.name ) }.${ ext }`;
-	return blobToFile( new Blob( [ outBuffer ], { type } ), fileName, type );
+	return outBuffer.buffer;
 }
 
 function isFileTypeSupported(
@@ -73,21 +96,30 @@ function isFileTypeSupported(
 	].includes( type );
 }
 
-export async function compressImage( file: File, quality = 0.82 ) {
-	if ( ! isFileTypeSupported( file.type ) ) {
+export async function compressImage(
+	buffer: ArrayBuffer,
+	type: string,
+	quality = 0.82
+) {
+	if ( ! isFileTypeSupported( type ) ) {
 		throw new Error( 'Unsupported file type' );
 	}
-	return convertImageFormat( file, file.type, quality );
+	return convertImageFormat( buffer, type, quality );
 }
 
 /**
  * Resizes an image using vips.
  *
- * @param file   Original file object.
+ * @param buffer Original file object.
+ * @param ext    File extension.
  * @param resize
  * @return Processed file object.
  */
-export async function resizeImage( file: File, resize: ImageSizeCrop ) {
+export async function resizeImage(
+	buffer: ArrayBuffer,
+	ext: string,
+	resize: ImageSizeCrop
+) {
 	const vips = await getVips();
 	const options: ThumbnailOptions = {
 		size: 'down',
@@ -103,14 +135,12 @@ export async function resizeImage( file: File, resize: ImageSizeCrop ) {
 
 	if ( ! resize.crop || true === resize.crop ) {
 		image = vips.Image.thumbnailBuffer(
-			new Uint8Array( await file.arrayBuffer() ),
+			new Uint8Array( buffer ),
 			resize.width,
 			options
 		);
 	} else {
-		image = vips.Image.newFromBuffer(
-			new Uint8Array( await file.arrayBuffer() )
-		);
+		image = vips.Image.newFromBuffer( new Uint8Array( buffer ) );
 
 		const { width, height } = image;
 
@@ -131,19 +161,16 @@ export async function resizeImage( file: File, resize: ImageSizeCrop ) {
 		image = image.crop( left, top, resize.width, resize.height );
 	}
 
-	const ext = getExtensionFromMimeType( file.type );
 	const outBuffer = image.writeToBuffer( `.${ ext }` );
 
-	const fileName = `${ getFileBasename( file.name ) }-${ image.width }x${
-		image.height
-	}.${ ext }`;
+	const result = {
+		buffer: outBuffer,
+		width: image.width,
+		height: image.height,
+	};
 
 	// Only call after `image` is no longer being used.
 	cleanup?.();
 
-	return blobToFile(
-		new Blob( [ outBuffer ], { type: file.type } ),
-		fileName,
-		file.type
-	);
+	return result;
 }


### PR DESCRIPTION
Fixes #241

See https://github.com/kleisauke/wasm-vips/issues/15#issuecomment-1825631671 for an example.

Haven't gotten this to work yet though...

Usually getting errors like:

```
Failed to construct 'Worker': 'vips.worker.js' is not a valid URL.
TypeError: Failed to execute 'fetch' on 'WorkerGlobalScope': Failed to parse URL from vips.wasm
```

To test:

1. `npm run start`
2. `npm run wp-now`
3. Go to `http://localhost:8889/wp-admin/post-new.php` in the browser
4. Drag image file into editor