### PR TITLE
Revamp preferences

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,7 +34,10 @@
 					"site_icon",
 					"site_logo",
 					"generate_sub_sizes",
-					"upload_request"
+					"upload_request",
+					"[a-z]+_outputFormat",
+					"[a-z]+_quality",
+					"gif_convert"
 				]
 			}
 		]

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,9 +23,20 @@ jobs:
             fail-fast: false
             matrix:
                 wp: ['latest']
+                shard: ['1/4', '2/4', '3/4', '4/4']
                 experimental: [false]
                 include:
                     - wp: 'trunk'
+                      shard: '1/4'
+                      experimental: true
+                    - wp: 'trunk'
+                      shard: '2/4'
+                      experimental: true
+                    - wp: 'trunk'
+                      shard: '3/4'
+                      experimental: true
+                    - wp: 'trunk'
+                      shard: '4/4'
                       experimental: true
         steps:
             - name: Checkout
@@ -75,7 +86,7 @@ jobs:
                   cd -
 
             - name: Run tests
-              run: npm run test:e2e
+              run: npm run test:e2e -- --shard=${{ matrix.shard }}
               env:
                   COLLECT_COVERAGE: ${{ matrix.wp == 'latest' }}
 
@@ -89,5 +100,5 @@ jobs:
               uses: actions/upload-artifact@v4
               if: always()
               with:
-                  name: failures-artifacts-${{ matrix.wp }}
+                  name: failures-artifacts-${{ matrix.wp }}-${{ matrix.shard }}
                   path: artifacts

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -96,9 +96,16 @@ jobs:
                   file: artifacts/e2e-coverage/coverage/lcov.info
                   flags: e2e
 
+            - name: Get artifact name
+              run: |
+                  ARTIFACT_NAME=${ARTIFACT_NAME//\//-}
+                  echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
+              env:
+                  ARTIFACT_NAME: failures-artifacts-${{ matrix.wp }}-${{ matrix.shard }}
+
             - name: Archive debug artifacts (screenshots, HTML snapshots)
               uses: actions/upload-artifact@v4
               if: always()
               with:
-                  name: failures-artifacts-${{ matrix.wp }}-${{ matrix.shard }}
+                  name: ${{ env.ARTIFACT_NAME }}
                   path: artifacts

--- a/packages/edit-post/src/preferencesModal/index.tsx
+++ b/packages/edit-post/src/preferencesModal/index.tsx
@@ -44,12 +44,25 @@ registerPlugin( 'media-experiments-preferences', {
 const defaultPreferences: MediaPreferences = {
 	// General.
 	requireApproval: true,
-	bigImageSizeThreshold: window.mediaExperiments.bigImageSizeThreshold,
-	clientSideThumbnails: true,
 	optimizeOnUpload: true,
+	thumbnailGeneration: 'smart',
 	imageLibrary: 'vips',
-	imageFormat: 'jpeg',
-	imageQuality: 82, // 82 for jpeg, 86 for webp.
+	bigImageSizeThreshold: window.mediaExperiments.bigImageSizeThreshold,
+	// Formats.
+	default_outputFormat: 'jpeg',
+	jpeg_outputFormat: 'jpeg',
+	jpeg_quality: 82,
+	png_outputFormat: 'webp',
+	png_quality: 82,
+	webp_outputFormat: 'webp',
+	webp_quality: 86,
+	avif_outputFormat: 'avif',
+	avif_quality: 80,
+	heic_outputFormat: 'avif',
+	heic_quality: 80,
+	gif_outputFormat: 'webp',
+	gif_quality: 80,
+	gif_convert: true,
 	// Media recording.
 	videoInput: undefined,
 	audioInput: undefined,

--- a/packages/edit-post/src/preferencesModal/modal.tsx
+++ b/packages/edit-post/src/preferencesModal/modal.tsx
@@ -6,12 +6,24 @@ import {
 	store as interfaceStore,
 } from '@wordpress/interface';
 import { useMemo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 
 import { store as recordingStore } from '../mediaRecording/store';
 import { FeatureNumberControl } from './numberControl';
 import { SelectFeature } from './selectFeature';
 import { EnableFeature } from './enableFeature';
+
+type InputFormat = 'jpeg' | 'webp' | 'avif' | 'png' | 'heic' | 'gif';
+type InputFormatLabel = 'JPEG' | 'PNG' | 'WebP' | 'AVIF' | 'HEIC' | 'GIF';
+
+const inputFormats: InputFormatLabel[] = [
+	'JPEG',
+	'PNG',
+	'WebP',
+	'AVIF',
+	'HEIC',
+	'GIF',
+];
 
 const EMPTY_ARRAY: never[] = [];
 
@@ -53,26 +65,49 @@ export function Modal() {
 							label={ __( 'Approval step', 'media-experiments' ) }
 						/>
 						<EnableFeature
-							featureName="clientSideThumbnails"
-							help={ __(
-								'Generate thumbnails on the client instead of the server.',
-								'media-experiments'
-							) }
-							label={ __(
-								'Thumbnail generation',
-								'media-experiments'
-							) }
-						/>
-						<EnableFeature
 							featureName="optimizeOnUpload"
 							help={ __(
-								'Compress and optimize media items during upload. Disabling restores old WordPress behavior.',
+								'Compress and optimize media items before uploading to the server.',
 								'media-experiments'
 							) }
 							label={ __(
 								'Pre-upload compression',
 								'media-experiments'
 							) }
+						/>
+						<SelectFeature
+							featureName="thumbnailGeneration"
+							help={ __(
+								'Preferred method for thumbnail generation.',
+								'media-experiments'
+							) }
+							label={ __(
+								'Thumbnail generation',
+								'media-experiments'
+							) }
+							options={ [
+								{
+									label: __(
+										'Legacy (server-side)',
+										'media-experiments'
+									),
+									value: 'server',
+								},
+								{
+									label: __(
+										'Regular (client-side)',
+										'media-experiments'
+									),
+									value: 'client',
+								},
+								{
+									label: __(
+										'Smart (saliency-aware)',
+										'media-experiments'
+									),
+									value: 'smart',
+								},
+							] }
 						/>
 						<SelectFeature
 							featureName="imageLibrary"
@@ -89,56 +124,6 @@ export function Modal() {
 								{
 									label: __( 'libvips', 'media-experiments' ),
 									value: 'vips',
-								},
-							] }
-						/>
-						<SelectFeature
-							featureName="imageFormat"
-							help={ __(
-								'Preferred file type to convert images to.',
-								'media-experiments'
-							) }
-							label={ __( 'Image Format', 'media-experiments' ) }
-							options={ [
-								{
-									label: __( 'JPEG', 'media-experiments' ),
-									value: 'jpeg',
-								},
-								{
-									label: __( 'WebP', 'media-experiments' ),
-									value: 'webp',
-								},
-								{
-									label: __( 'AVIF', 'media-experiments' ),
-									value: 'avif',
-								},
-								{
-									label: __(
-										'None (do not change file type)',
-										'media-experiments'
-									),
-									value: 'none',
-								},
-							] }
-						/>
-						{ /* default for jpeg: 82, for webp: 86 */ }
-						<FeatureNumberControl
-							className="interface-preferences-modal__option interface-preferences-modal__option--number"
-							label={ __( 'Image Quality', 'media-experiments' ) }
-							isShiftStepEnabled={ true }
-							featureName="imageQuality"
-							shiftStep={ 5 }
-							max={ 100 }
-							min={ 1 }
-							units={ [
-								{
-									value: '%',
-									label: '%',
-									a11yLabel: __(
-										'Percent (%)',
-										'media-experiments'
-									),
-									step: 1,
 								},
 							] }
 						/>
@@ -166,6 +151,152 @@ export function Modal() {
 							] }
 						/>
 					</PreferencesModalSection>
+				),
+			},
+			{
+				name: 'formats',
+				tabLabel: __( 'Formats', 'media-experiments' ),
+				content: (
+					<>
+						<PreferencesModalSection
+							title={ _x(
+								'Default',
+								'image format',
+								'media-experiments'
+							) }
+							description={ __(
+								'Specify the default format for newly generated images, such as poster images.',
+								'media-experiments'
+							) }
+						>
+							<SelectFeature
+								featureName="default_outputFormat"
+								help={ __(
+									'Default file type for new images.',
+									'media-experiments'
+								) }
+								label={ __(
+									'Image Format',
+									'media-experiments'
+								) }
+								options={ [
+									{
+										label: 'JPEG',
+										value: 'jpeg',
+									},
+									{
+										label: 'PNG',
+										value: 'png',
+									},
+									{
+										label: 'WebP',
+										value: 'webp',
+									},
+									{
+										label: 'AVIF',
+										value: 'avif',
+									},
+								] }
+							/>
+						</PreferencesModalSection>
+						{ inputFormats.map( ( inputFormat ) => (
+							<PreferencesModalSection
+								key={ inputFormat }
+								title={ inputFormat }
+								description={ sprintf(
+									/* translators: %s: image format. */
+									__(
+										'Tweak the behavior for %s images.',
+										'media-experiments'
+									),
+									inputFormat
+								) }
+							>
+								<SelectFeature
+									featureName={ `${
+										inputFormat.toLowerCase() as InputFormat
+									}_outputFormat` }
+									help={ __(
+										'Preferred file type to convert images to.',
+										'media-experiments'
+									) }
+									label={ __(
+										'Image Format',
+										'media-experiments'
+									) }
+									options={ [
+										{
+											label: 'JPEG',
+											value: 'jpeg',
+										},
+										{
+											label: 'PNG',
+											value: 'png',
+										},
+										{
+											label: 'WebP',
+											value: 'webp',
+										},
+										{
+											label: 'AVIF',
+											value: 'avif',
+										},
+									].map( ( option ) => {
+										if ( inputFormat === option.label ) {
+											option.label = sprintf(
+												/* translators: %s: image format */
+												__(
+													'%s (unchanged)',
+													'media-experiments'
+												),
+												inputFormat
+											);
+										}
+										return option;
+									} ) }
+								/>
+								{ /* default for jpeg: 82, for webp: 86 */ }
+								<FeatureNumberControl
+									className="interface-preferences-modal__option interface-preferences-modal__option--number"
+									label={ __(
+										'Image Quality',
+										'media-experiments'
+									) }
+									isShiftStepEnabled={ true }
+									featureName={ `${
+										inputFormat.toLowerCase() as InputFormat
+									}_quality` }
+									shiftStep={ 5 }
+									max={ 100 }
+									min={ 1 }
+									units={ [
+										{
+											value: '%',
+											label: '%',
+											a11yLabel: __(
+												'Percent (%)',
+												'media-experiments'
+											),
+											step: 1,
+										},
+									] }
+								/>
+								{ 'GIF' === inputFormat ? (
+									<EnableFeature
+										featureName="gif_convert"
+										help={ __(
+											'Convert animated GIFs to videos.',
+											'media-experiments'
+										) }
+										label={ __(
+											'Convert animated GIFs',
+											'media-experiments'
+										) }
+									/>
+								) : null }
+							</PreferencesModalSection>
+						) ) }
+					</>
 				),
 			},
 			{

--- a/packages/edit-post/src/preferencesModal/modal.tsx
+++ b/packages/edit-post/src/preferencesModal/modal.tsx
@@ -189,6 +189,10 @@ export function Modal() {
 										value: 'png',
 									},
 									{
+										label: 'GIF',
+										value: 'gif',
+									},
+									{
 										label: 'WebP',
 										value: 'webp',
 									},
@@ -232,6 +236,10 @@ export function Modal() {
 										{
 											label: 'PNG',
 											value: 'png',
+										},
+										{
+											label: 'GIF',
+											value: 'gif',
 										},
 										{
 											label: 'WebP',

--- a/packages/edit-post/src/types.ts
+++ b/packages/edit-post/src/types.ts
@@ -1,6 +1,11 @@
 import { type BlockInstance } from '@wordpress/blocks';
 
-import type { Attachment, ImageFormat, ImageLibrary } from '@mexp/upload-media';
+import type {
+	Attachment,
+	ImageFormat,
+	ImageLibrary,
+	ThumbnailGeneration,
+} from '@mexp/upload-media';
 
 export type BulkOptimizationAttachmentData = Pick<
 	Attachment,
@@ -16,12 +21,25 @@ export type BulkOptimizationAttachmentData = Pick<
 export type MediaPreferences = {
 	// General.
 	requireApproval: boolean;
-	bigImageSizeThreshold: number;
-	clientSideThumbnails: boolean;
 	optimizeOnUpload: boolean;
+	thumbnailGeneration: ThumbnailGeneration;
 	imageLibrary: ImageLibrary;
-	imageFormat: ImageFormat;
-	imageQuality: number;
+	bigImageSizeThreshold: number;
+	// Formats.
+	default_outputFormat: ImageFormat;
+	jpeg_outputFormat: ImageFormat;
+	jpeg_quality: number;
+	png_outputFormat: ImageFormat;
+	png_quality: number;
+	webp_outputFormat: ImageFormat;
+	webp_quality: number;
+	avif_outputFormat: ImageFormat;
+	avif_quality: number;
+	heic_outputFormat: ImageFormat;
+	heic_quality: number;
+	gif_outputFormat: ImageFormat;
+	gif_quality: number;
+	gif_convert: boolean;
 	// Media recording.
 	videoInput?: string;
 	audioInput?: string;

--- a/packages/upload-media/src/index.ts
+++ b/packages/upload-media/src/index.ts
@@ -13,6 +13,7 @@ import type {
 	ImageFormat,
 	ImageLibrary,
 	ImageSizeCrop,
+	ThumbnailGeneration,
 } from './store/types';
 import { UploadError } from './uploadError';
 
@@ -28,6 +29,7 @@ export type {
 	ImageFormat,
 	ImageLibrary,
 	ImageSizeCrop,
+	ThumbnailGeneration,
 };
 
 export { uploadStore as store, UploadError };

--- a/packages/upload-media/src/store/actions.ts
+++ b/packages/upload-media/src/store/actions.ts
@@ -1140,13 +1140,13 @@ export function optimizeImageItem(
 					if ( 'browser' === imageLibrary ) {
 						file = await convertImageFormat(
 							item.file,
-							'image/jpeg',
+							`image/${ outputFormat }`,
 							outputQuality / 100
 						);
 					} else {
 						file = await vipsConvertImageFormat(
 							item.file,
-							'image/jpeg',
+							`image/${ outputFormat }`,
 							outputQuality / 100
 						);
 					}

--- a/packages/upload-media/src/store/actions.ts
+++ b/packages/upload-media/src/store/actions.ts
@@ -1135,6 +1135,16 @@ export function optimizeImageItem(
 					);
 					break;
 
+				case 'gif':
+					// Browsers don't typically support image/gif in HTMLCanvasElement.toBlob() yet, so always use vips.
+					// See https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob
+					file = await vipsConvertImageFormat(
+						item.file,
+						'image/avif',
+						outputQuality / 100
+					);
+					break;
+
 				case 'jpeg':
 				case 'png':
 					if ( 'browser' === imageLibrary ) {

--- a/packages/upload-media/src/store/types.ts
+++ b/packages/upload-media/src/store/types.ts
@@ -210,6 +210,6 @@ export type ImageSizeCrop = {
 
 export type ImageLibrary = 'browser' | 'vips';
 
-export type ImageFormat = 'jpeg' | 'webp' | 'avif' | 'png';
+export type ImageFormat = 'jpeg' | 'webp' | 'avif' | 'png' | 'gif';
 
 export type ThumbnailGeneration = 'server' | 'client' | 'smart';

--- a/packages/upload-media/src/store/types.ts
+++ b/packages/upload-media/src/store/types.ts
@@ -210,4 +210,6 @@ export type ImageSizeCrop = {
 
 export type ImageLibrary = 'browser' | 'vips';
 
-export type ImageFormat = 'jpeg' | 'webp' | 'avif' | 'none';
+export type ImageFormat = 'jpeg' | 'webp' | 'avif' | 'png';
+
+export type ThumbnailGeneration = 'server' | 'client' | 'smart';

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -115,7 +115,7 @@ export async function resizeImage(
 	buffer: ArrayBuffer,
 	ext: string,
 	resize: ImageSizeCrop,
-	smartCrop: boolean,
+	smartCrop: boolean = false
 ) {
 	const vips = await getVips();
 	const options: ThumbnailOptions = {

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -105,15 +105,17 @@ export async function compressImage(
 /**
  * Resizes an image using vips.
  *
- * @param buffer Original file object.
- * @param ext    File extension.
- * @param resize
+ * @param buffer    Original file object.
+ * @param ext       File extension.
+ * @param resize    Resize options.
+ * @param smartCrop Whether to use smart cropping (i.e. saliency-aware).
  * @return Processed file object.
  */
 export async function resizeImage(
 	buffer: ArrayBuffer,
 	ext: string,
-	resize: ImageSizeCrop
+	resize: ImageSizeCrop,
+	smartCrop: boolean,
 ) {
 	const vips = await getVips();
 	const options: ThumbnailOptions = {
@@ -129,6 +131,9 @@ export async function resizeImage(
 	let image;
 
 	if ( ! resize.crop || true === resize.crop ) {
+		if ( smartCrop ) {
+			options.crop = 'attention';
+		}
 		image = vips.Image.thumbnailBuffer( buffer, resize.width, options );
 	} else {
 		image = vips.Image.newFromBuffer( buffer );

--- a/packages/vips/src/test/resizeImage.ts
+++ b/packages/vips/src/test/resizeImage.ts
@@ -87,6 +87,7 @@ describe( 'resizeImage', () => {
 		} );
 		expect( mockCrop ).not.toHaveBeenCalled();
 	} );
+
 	it( 'resizes with center crop and zero height', async () => {
 		const jpegFile = new File( [ '<BLOB>' ], 'example.jpg', {
 			lastModified: 1234567891,
@@ -102,6 +103,57 @@ describe( 'resizeImage', () => {
 
 		expect( mockThumbnailBuffer ).toHaveBeenCalledWith( buffer, 100, {
 			crop: 'centre',
+			size: 'down',
+		} );
+		expect( mockCrop ).not.toHaveBeenCalled();
+	} );
+
+	it( 'resizes without crop and attention strategy', async () => {
+		const jpegFile = new File( [ '<BLOB>' ], 'example.jpg', {
+			lastModified: 1234567891,
+			type: 'image/jpeg',
+		} );
+		const buffer = await jpegFile.arrayBuffer();
+
+		await resizeImage(
+			buffer,
+			'jpeg',
+			{
+				width: 100,
+				height: 100,
+			},
+			true
+		);
+
+		expect( mockThumbnailBuffer ).toHaveBeenCalledWith( buffer, 100, {
+			height: 100,
+			size: 'down',
+			crop: 'attention',
+		} );
+		expect( mockCrop ).not.toHaveBeenCalled();
+	} );
+
+	it( 'resizes with center crop and attention strategy', async () => {
+		const jpegFile = new File( [ '<BLOB>' ], 'example.jpg', {
+			lastModified: 1234567891,
+			type: 'image/jpeg',
+		} );
+		const buffer = await jpegFile.arrayBuffer();
+
+		await resizeImage(
+			buffer,
+			'jpeg',
+			{
+				width: 100,
+				height: 100,
+				crop: true,
+			},
+			true
+		);
+
+		expect( mockThumbnailBuffer ).toHaveBeenCalledWith( buffer, 100, {
+			height: 100,
+			crop: 'attention',
 			size: 'down',
 		} );
 		expect( mockCrop ).not.toHaveBeenCalled();

--- a/tests/e2e/specs/animatedGifs.spec.ts
+++ b/tests/e2e/specs/animatedGifs.spec.ts
@@ -22,7 +22,11 @@ test.describe( 'Animated GIFs', () => {
 		await page.evaluate( () => {
 			window.wp.data
 				.dispatch( 'core/preferences' )
-				.set( 'media-experiments/preferences', 'imageFormat', 'jpeg' );
+				.set(
+					'media-experiments/preferences',
+					'default_outputFormat',
+					'jpeg'
+				);
 			window.wp.data
 				.dispatch( 'core/preferences' )
 				.set(

--- a/tests/e2e/specs/imageBlock.spec.ts
+++ b/tests/e2e/specs/imageBlock.spec.ts
@@ -149,7 +149,7 @@ test.describe( 'Image block', () => {
 							.dispatch( 'core/preferences' )
 							.set(
 								'media-experiments/preferences',
-								`${ fmt }_outputFormat`,
+								'png_outputFormat',
 								fmt
 							);
 						window.wp.data
@@ -270,7 +270,7 @@ test.describe( 'Image block', () => {
 							.dispatch( 'core/preferences' )
 							.set(
 								'media-experiments/preferences',
-								'imageFormat',
+								'png_outputFormat',
 								fmt
 							);
 						window.wp.data

--- a/tests/e2e/specs/imageBlock.spec.ts
+++ b/tests/e2e/specs/imageBlock.spec.ts
@@ -3,49 +3,48 @@ import type { ImageFormat, ImageLibrary } from '@mexp/upload-media';
 import { test, expect } from '../fixtures';
 
 const scenarios: {
-	imageFormat: ImageFormat;
+	outputFormat: ImageFormat;
 	imageLibrary: ImageLibrary;
 	expectedMimeType: string;
 }[] = [
 	{
-		imageFormat: 'jpeg',
+		outputFormat: 'jpeg',
 		imageLibrary: 'browser',
 		expectedMimeType: 'image/jpeg',
 	},
 	{
-		imageFormat: 'webp',
+		outputFormat: 'webp',
 		imageLibrary: 'browser',
 		expectedMimeType: 'image/webp',
 	},
-	// TODO: skip or test behavior separately, as it's not a supported scenario.
 	{
-		imageFormat: 'avif',
+		outputFormat: 'avif',
 		imageLibrary: 'browser',
 		expectedMimeType: 'image/avif',
 	},
 	{
-		imageFormat: 'none',
+		outputFormat: 'png',
 		imageLibrary: 'browser',
 		// Default image in tests is a png, so type should be unchanged.
 		expectedMimeType: 'image/png',
 	},
 	{
-		imageFormat: 'jpeg',
+		outputFormat: 'jpeg',
 		imageLibrary: 'vips',
 		expectedMimeType: 'image/jpeg',
 	},
 	{
-		imageFormat: 'webp',
+		outputFormat: 'webp',
 		imageLibrary: 'vips',
 		expectedMimeType: 'image/webp',
 	},
 	{
-		imageFormat: 'avif',
+		outputFormat: 'avif',
 		imageLibrary: 'vips',
 		expectedMimeType: 'image/avif',
 	},
 	{
-		imageFormat: 'none',
+		outputFormat: 'png',
 		imageLibrary: 'vips',
 		// Default image in tests is a png, so type should be unchanged.
 		expectedMimeType: 'image/png',
@@ -59,11 +58,11 @@ test.describe( 'Image block', () => {
 
 	test.describe( 'uploads a file and allows optimizing it afterwards', () => {
 		for ( const {
-			imageFormat,
+			outputFormat,
 			imageLibrary,
 			expectedMimeType,
 		} of scenarios ) {
-			test( `uses ${ imageFormat }@${ imageLibrary } to convert to ${ expectedMimeType }`, async ( {
+			test( `uses ${ outputFormat }@${ imageLibrary } to convert to ${ expectedMimeType }`, async ( {
 				admin,
 				page,
 				editor,
@@ -72,12 +71,12 @@ test.describe( 'Image block', () => {
 			} ) => {
 				test.skip(
 					browserName === 'webkit' &&
-						( imageLibrary === 'vips' || imageFormat === 'avif' ),
+						( imageLibrary === 'vips' || outputFormat === 'avif' ),
 					'No cross-origin isolation in Playwright WebKit builds yet, see https://github.com/microsoft/playwright/issues/14043'
 				);
 
 				test.skip(
-					browserName === 'webkit' && imageFormat === 'webp',
+					browserName === 'webkit' && outputFormat === 'webp',
 					'WebKit does not currently support Canvas.toBlob with WebP'
 				);
 
@@ -89,13 +88,14 @@ test.describe( 'Image block', () => {
 
 				await admin.createNewPost();
 
+				// Ensure the initially uploaded PNG is left untouched.
 				await page.evaluate( () => {
 					window.wp.data
 						.dispatch( 'core/preferences' )
 						.set(
 							'media-experiments/preferences',
-							'imageFormat',
-							'none'
+							'png_outputFormat',
+							'png'
 						);
 					window.wp.data
 						.dispatch( 'core/preferences' )
@@ -149,7 +149,7 @@ test.describe( 'Image block', () => {
 							.dispatch( 'core/preferences' )
 							.set(
 								'media-experiments/preferences',
-								'imageFormat',
+								`${ fmt }_outputFormat`,
 								fmt
 							);
 						window.wp.data
@@ -160,7 +160,7 @@ test.describe( 'Image block', () => {
 								lib
 							);
 					},
-					[ imageFormat, imageLibrary ]
+					[ outputFormat, imageLibrary ]
 				);
 
 				await page.getByRole( 'button', { name: 'Optimize' } ).click();
@@ -234,11 +234,11 @@ test.describe( 'Image block', () => {
 
 	test.describe( 'optimizes a file on upload', () => {
 		for ( const {
-			imageFormat,
+			outputFormat,
 			imageLibrary,
 			expectedMimeType,
 		} of scenarios ) {
-			test( `uses ${ imageFormat }@${ imageLibrary } to convert to ${ expectedMimeType }`, async ( {
+			test( `uses ${ outputFormat }@${ imageLibrary } to convert to ${ expectedMimeType }`, async ( {
 				admin,
 				page,
 				editor,
@@ -247,12 +247,12 @@ test.describe( 'Image block', () => {
 			} ) => {
 				test.skip(
 					browserName === 'webkit' &&
-						( imageLibrary === 'vips' || imageFormat === 'avif' ),
+						( imageLibrary === 'vips' || outputFormat === 'avif' ),
 					'No cross-origin isolation in Playwright WebKit builds yet, see https://github.com/microsoft/playwright/issues/14043'
 				);
 
 				test.skip(
-					browserName === 'webkit' && imageFormat === 'webp',
+					browserName === 'webkit' && outputFormat === 'webp',
 					'WebKit does not currently support Canvas.toBlob with WebP'
 				);
 
@@ -281,7 +281,7 @@ test.describe( 'Image block', () => {
 								lib
 							);
 					},
-					[ imageFormat, imageLibrary ]
+					[ outputFormat, imageLibrary ]
 				);
 
 				await editor.insertBlock( { name: 'core/image' } );

--- a/tests/e2e/specs/videoBlock.spec.ts
+++ b/tests/e2e/specs/videoBlock.spec.ts
@@ -68,6 +68,14 @@ test.describe( 'Video block', () => {
 			/8oLRkaz/
 		);
 
+		const blockAttributes = await page.evaluate(
+			() =>
+				window.wp.data.select( 'core/block-editor' ).getSelectedBlock()
+					?.attributes ?? {}
+		);
+		await expect( blockAttributes.src ).toMatch( /\.mp4$/ );
+		await expect( blockAttributes.poster ).toMatch( /-poster\.jpeg$/ );
+
 		await expect(
 			page.getByRole( 'button', { name: 'Remove audio channel' } )
 		).toBeVisible();


### PR DESCRIPTION
* Adds support for saliency-aware cropping
* Splits up preferences settings and adds section for each input format

<img width="808" alt="Screenshot 2023-12-20 at 14 38 31" src="https://github.com/swissspidy/media-experiments/assets/841956/a30a1cc7-738d-4b2c-a746-40216842dfc7">
<img width="817" alt="Screenshot 2023-12-20 at 14 38 26" src="https://github.com/swissspidy/media-experiments/assets/841956/22e4331f-20a9-41f8-bf70-9b04ae5a9e57">


Fixes #256
Fixes #5