### PR TITLE
Bump wasm-vips to 0.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25405,9 +25405,9 @@
 			}
 		},
 		"node_modules/wasm-vips": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.8.tgz",
-			"integrity": "sha512-2Ghqubm0WfsBT3VsObwnMmEZB3tngCa8/yk7LU3QzOIqSPb0W3FQmgmOpWLg1DS4RMuAEeErLPxwbucdrL2umQ==",
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.9.tgz",
+			"integrity": "sha512-6ljaCFNxE6mUqVQM/y/OoNLSCh0+KHP5h78L9xbgAMoXjRoy188E4m7ZVUlkO4sMjVnDtcsc1CNPJONtOvzlOA==",
 			"engines": {
 				"node": ">=16.4.0"
 			}
@@ -26622,7 +26622,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@mexp/media-utils": "../media-utils",
-				"wasm-vips": "^0.0.8"
+				"wasm-vips": "^0.0.9"
 			},
 			"engines": {
 				"node": ">=20"

--- a/packages/vips/package.json
+++ b/packages/vips/package.json
@@ -32,6 +32,6 @@
 	},
 	"dependencies": {
 		"@mexp/media-utils": "../media-utils",
-		"wasm-vips": "^0.0.8"
+		"wasm-vips": "^0.0.9"
 	}
 }

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -32,9 +32,13 @@ async function getVips(): Promise< typeof VipsInstance > {
 		return vipsInstance;
 	}
 
+	const mainBlobUrl = URL.createObjectURL(
+		await ( await fetch( `${ VIPS_CDN_URL }/vips.js` ) ).blob()
+	);
+
 	vipsInstance = await Vips( {
 		locateFile: ( fileName: string ) => `${ VIPS_CDN_URL }/${ fileName }`,
-		workaroundCors: true,
+		mainScriptUrlOrBlob: mainBlobUrl,
 		preRun: ( module: EmscriptenModule ) => {
 			// https://github.com/kleisauke/wasm-vips/issues/13#issuecomment-1073246828
 			module.setAutoDeleteLater( true );

--- a/packages/vips/src/test/resizeImage.ts
+++ b/packages/vips/src/test/resizeImage.ts
@@ -8,11 +8,11 @@ const mockNewFromBuffer = jest.fn( () => new MockImage() );
 class MockImage {
 	width = 100;
 	height = 100;
+	pageHeight = 100;
 	crop = mockCrop;
 	writeToBuffer = jest.fn( () => ( {
 		buffer: '',
 	} ) );
-	getInt = jest.fn( () => 1 );
 }
 
 class MockVipsImage {


### PR DESCRIPTION
- Worker script is inlined into the main output file (see https://github.com/kleisauke/wasm-vips/commit/d6cdcbbb3104b3a3688c3fd71320e88945ab30b1).
- Simplify resize logic using the `pageHeight` property (see https://github.com/kleisauke/wasm-vips/commit/6f1e1b94695973fa4d80e40378ae4ab840640831).
