### PR TITLE
Load wasm-vips locally for offline use (#292)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,8 +19,7 @@
 	"globals": {
 		"FFMPEG_CDN_URL": "readonly",
 		"MEDIAPIPE_CDN_URL": "readonly",
-		"PDFJS_CDN_URL": "readonly",
-		"VIPS_CDN_URL": "readonly"
+		"PDFJS_CDN_URL": "readonly"
 	},
 	"rules": {
 		"@wordpress/no-unused-vars-before-return": [

--- a/jest-unit.config.js
+++ b/jest-unit.config.js
@@ -21,4 +21,7 @@ module.exports = {
 		MEDIAPIPE_CDN_URL: 'https://example.com',
 		PDFJS_CDN_URL: 'https://example.com',
 	},
+	moduleNameMapper: {
+		'.+\\.wasm$': '<rootDir>/tests/js/wasm-stub.js',
+	},
 };

--- a/jest-unit.config.js
+++ b/jest-unit.config.js
@@ -20,6 +20,5 @@ module.exports = {
 		FFMPEG_CDN_URL: 'https://example.com',
 		MEDIAPIPE_CDN_URL: 'https://example.com',
 		PDFJS_CDN_URL: 'https://example.com',
-		VIPS_CDN_URL: 'https://example.com',
 	},
 };

--- a/packages/vips/src/@types/global.d.ts
+++ b/packages/vips/src/@types/global.d.ts
@@ -1,5 +1,0 @@
-declare global {
-	const VIPS_CDN_URL: string;
-}
-
-export type {};

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -1,12 +1,15 @@
 import Vips from 'wasm-vips';
 
 // @ts-expect-error
+// eslint-disable-next-line import/no-unresolved
 import VipsModule from 'wasm-vips/vips.wasm';
 
 // @ts-expect-error
+// eslint-disable-next-line import/no-unresolved
 import VipsHeifModule from 'wasm-vips/vips-heif.wasm';
 
 // @ts-expect-error
+// eslint-disable-next-line import/no-unresolved
 import VipsJxlModule from 'wasm-vips/vips-jxl.wasm';
 
 import { getExtensionFromMimeType } from '@mexp/mime';

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -1,6 +1,12 @@
 import Vips from 'wasm-vips';
+
+// @ts-expect-error
 import VipsModule from 'wasm-vips/vips.wasm';
+
+// @ts-expect-error
 import VipsHeifModule from 'wasm-vips/vips-heif.wasm';
+
+// @ts-expect-error
 import VipsJxlModule from 'wasm-vips/vips-jxl.wasm';
 
 import { getExtensionFromMimeType } from '@mexp/mime';

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -1,7 +1,7 @@
-const Vips = require( 'wasm-vips' ) as (
-	config?: Parameters< typeof VipsInstance >[ 0 ]
-) => Promise< NonNullable< typeof VipsInstance > >;
-import type VipsInstance from 'wasm-vips';
+import Vips from 'wasm-vips';
+import VipsModule from 'wasm-vips/vips.wasm';
+import VipsHeifModule from 'wasm-vips/vips-heif.wasm';
+import VipsJxlModule from 'wasm-vips/vips-jxl.wasm';
 
 import { getExtensionFromMimeType } from '@mexp/mime';
 
@@ -19,7 +19,7 @@ type EmscriptenModule = {
 
 let cleanup: () => void;
 
-let vipsInstance: typeof VipsInstance;
+let vipsInstance: typeof Vips;
 
 type ItemId = string;
 
@@ -28,18 +28,23 @@ type ItemId = string;
  *
  * Reuses any existing instance.
  */
-async function getVips(): Promise< typeof VipsInstance > {
+async function getVips(): Promise< typeof Vips > {
 	if ( vipsInstance ) {
 		return vipsInstance;
 	}
 
-	const mainBlobUrl = URL.createObjectURL(
-		await ( await fetch( `${ VIPS_CDN_URL }/vips.js` ) ).blob()
-	);
-
 	vipsInstance = await Vips( {
-		locateFile: ( fileName: string ) => `${ VIPS_CDN_URL }/${ fileName }`,
-		mainScriptUrlOrBlob: mainBlobUrl,
+		locateFile: ( fileName: string ) => {
+			if ( fileName.endsWith( 'vips.wasm' ) ) {
+				fileName = VipsModule;
+			} else if ( fileName.endsWith( 'vips-heif.wasm' ) ) {
+				fileName = VipsHeifModule;
+			} else if ( fileName.endsWith( 'vips-jxl.wasm' ) ) {
+				fileName = VipsJxlModule;
+			}
+
+			return self.location.origin + fileName;
+		},
 		preRun: ( module: EmscriptenModule ) => {
 			// https://github.com/kleisauke/wasm-vips/issues/13#issuecomment-1073246828
 			module.setAutoDeleteLater( true );

--- a/patches/wasm-vips+0.0.9.patch
+++ b/patches/wasm-vips+0.0.9.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/wasm-vips/package.json b/node_modules/wasm-vips/package.json
+index ed69597..22d63c0 100644
+--- a/node_modules/wasm-vips/package.json
++++ b/node_modules/wasm-vips/package.json
+@@ -25,7 +25,10 @@
+       },
+       "default": "./lib/vips.js"
+     },
+-    "./versions": "./versions.json"
++    "./versions": "./versions.json",
++    "./vips.wasm": "./lib/vips.wasm",
++    "./vips-heif.wasm": "./lib/vips-heif.wasm",
++    "./vips-jxl.wasm": "./lib/vips-jxl.wasm"
+   },
+   "main": "lib/vips-node.js",
+   "browser": "lib/vips.js",

--- a/tests/js/wasm-stub.js
+++ b/tests/js/wasm-stub.js
@@ -1,0 +1,7 @@
+module.exports = {
+	process() {
+		return {
+			code: 'module.exports = ""',
+		};
+	},
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const { resolve, dirname, basename } = require( 'node:path' );
-const { readFileSync } = require( 'node:fs' );
 
 const { DefinePlugin } = require( 'webpack' );
 const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );


### PR DESCRIPTION
Load wasm-vips locally instead of from a CDN, enabling its features to work offline.

---

Note: the patch is temporary, I'll include that in the next release of wasm-vips.