### PR TITLE
Serve WASM files with the correct mime type

### DIFF
--- a/inc/default-filters.php
+++ b/inc/default-filters.php
@@ -21,6 +21,8 @@ add_action( 'enqueue_block_assets', __NAMESPACE__ . '\enqueue_block_assets' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_fields' );
 add_action( 'init', __NAMESPACE__ . '\register_attachment_post_meta' );
 
+add_filter( 'mod_rewrite_rules', __NAMESPACE__ . '\filter_mod_rewrite_rules' );
+
 add_filter( 'big_image_size_threshold', __NAMESPACE__ . '\filter_big_image_size_threshold' );
 add_filter( 'image_save_progressive', __NAMESPACE__ . '\filter_image_save_progressive', 10, 2 );
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1210,3 +1210,19 @@ function rest_post_dispatch_add_server_timing( $response ) {
 
 	return $response;
 }
+
+/**
+ * Filters the list of rewrite rules formatted for output to an .htaccess file.
+ *
+ * Adds support for serving wasm-vips locally.
+ *
+ * @param string $rules mod_rewrite Rewrite rules formatted for .htaccess.
+ * @return string Filtered rewrite rules.
+ */
+function filter_mod_rewrite_rules( string $rules ) {
+	$rules .= "\n# BEGIN Media Experiments\n" .
+				"AddType application/wasm wasm\n" .
+				"# END Media Experiments\n";
+
+	return $rules;
+}


### PR DESCRIPTION
When WordPress is using Apache, this enforces the correct mime type for serving `.wasm` files.

When using nginx, one has to do this themselves.

Only relevant for #603, as currently the files are served from a CDN.