### PR TITLE
Load wasm-vips locally for offline use (#292)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,8 +19,7 @@
 	"globals": {
 		"FFMPEG_CDN_URL": "readonly",
 		"MEDIAPIPE_CDN_URL": "readonly",
-		"PDFJS_CDN_URL": "readonly",
-		"VIPS_CDN_URL": "readonly"
+		"PDFJS_CDN_URL": "readonly"
 	},
 	"rules": {
 		"@wordpress/no-unused-vars-before-return": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,7 @@
 			"error",
 			{
 				"allow": [
+					"__webpack_.*__",
 					"WP_REST_API_.*",
 					"featured_media",
 					"alt_text",

--- a/inc/default-filters.php
+++ b/inc/default-filters.php
@@ -21,6 +21,8 @@ add_action( 'enqueue_block_assets', __NAMESPACE__ . '\enqueue_block_assets' );
 add_action( 'rest_api_init', __NAMESPACE__ . '\register_rest_fields' );
 add_action( 'init', __NAMESPACE__ . '\register_attachment_post_meta' );
 
+add_filter( 'mod_rewrite_rules', __NAMESPACE__ . '\filter_mod_rewrite_rules' );
+
 add_filter( 'big_image_size_threshold', __NAMESPACE__ . '\filter_big_image_size_threshold' );
 add_filter( 'image_save_progressive', __NAMESPACE__ . '\filter_image_save_progressive', 10, 2 );
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -214,6 +214,7 @@ function register_assets(): void {
 					'pngInterlaced'             => $png_interlaced,
 					'gifInterlaced'             => $gif_interlaced,
 					'mediaSourceTerms'          => $media_source_terms,
+					'publicPath'                => plugins_url( 'build/', __DIR__ ),
 				]
 			)
 		),
@@ -323,6 +324,7 @@ function enqueue_block_editor_assets(): void {
 					'pngInterlaced'             => $png_interlaced,
 					'gifInterlaced'             => $gif_interlaced,
 					'mediaSourceTerms'          => $media_source_terms,
+					'publicPath'                => plugins_url( 'build/', __DIR__ ),
 				]
 			)
 		),

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1210,3 +1210,19 @@ function rest_post_dispatch_add_server_timing( $response ) {
 
 	return $response;
 }
+
+/**
+ * Filters the list of rewrite rules formatted for output to an .htaccess file.
+ *
+ * Adds support for serving wasm-vips locally.
+ *
+ * @param string $rules mod_rewrite Rewrite rules formatted for .htaccess.
+ * @return string Filtered rewrite rules.
+ */
+function filter_mod_rewrite_rules( string $rules ) {
+	$rules .= "\n# BEGIN Media Experiments\n" .
+				"AddType application/wasm wasm\n" .
+				"# END Media Experiments\n";
+
+	return $rules;
+}

--- a/jest-unit.config.js
+++ b/jest-unit.config.js
@@ -21,4 +21,7 @@ module.exports = {
 		MEDIAPIPE_CDN_URL: 'https://example.com',
 		PDFJS_CDN_URL: 'https://example.com',
 	},
+	moduleNameMapper: {
+		'.+\\.wasm$': '<rootDir>/tests/js/wasm-stub.js',
+	},
 };

--- a/jest-unit.config.js
+++ b/jest-unit.config.js
@@ -20,6 +20,5 @@ module.exports = {
 		FFMPEG_CDN_URL: 'https://example.com',
 		MEDIAPIPE_CDN_URL: 'https://example.com',
 		PDFJS_CDN_URL: 'https://example.com',
-		VIPS_CDN_URL: 'https://example.com',
 	},
 };

--- a/packages/editor/src/@types/global.d.ts
+++ b/packages/editor/src/@types/global.d.ts
@@ -9,6 +9,8 @@ type MediaSourceTerm =
 	| 'subtitles-generation';
 
 declare global {
+	let __webpack_public_path__: string;
+
 	interface Window {
 		mediaExperiments: {
 			bigImageSizeThreshold: number;
@@ -19,6 +21,7 @@ declare global {
 			gifInterlaced: boolean;
 			availableImageSizes: Record< string, ImageSizeCrop >;
 			mediaSourceTerms: Record< MediaSourceTerm, number >;
+			publicPath: string;
 		};
 	}
 }

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,3 +1,8 @@
+// The __webpack_public_path__ assignment will be done after the imports.
+// That's why the public path assignment is in its own dedicated module and imported here at the very top.
+// See https://webpack.js.org/guides/public-path/#on-the-fly
+import './publicPath';
+
 import './uploadQueue';
 import './transforms';
 import './gifBlock';

--- a/packages/editor/src/publicPath.ts
+++ b/packages/editor/src/publicPath.ts
@@ -1,0 +1,1 @@
+__webpack_public_path__ = window.mediaExperiments.publicPath;

--- a/packages/upload-media/src/@types/global.d.ts
+++ b/packages/upload-media/src/@types/global.d.ts
@@ -1,0 +1,5 @@
+declare global {
+	let __webpack_public_path__: string;
+}
+
+export type {};

--- a/packages/upload-media/src/store/utils/vips.ts
+++ b/packages/upload-media/src/store/utils/vips.ts
@@ -11,6 +11,8 @@ const createVipsWorker = createWorkerFactory(
 );
 const vipsWorker = createVipsWorker();
 
+void vipsWorker.setLocation( __webpack_public_path__ );
+
 export async function vipsConvertImageFormat(
 	id: QueueItemId,
 	file: File,

--- a/packages/vips/src/@types/global.d.ts
+++ b/packages/vips/src/@types/global.d.ts
@@ -1,5 +1,0 @@
-declare global {
-	const VIPS_CDN_URL: string;
-}
-
-export type {};

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -1,12 +1,15 @@
 import Vips from 'wasm-vips';
 
 // @ts-expect-error
+// eslint-disable-next-line import/no-unresolved
 import VipsModule from 'wasm-vips/vips.wasm';
 
 // @ts-expect-error
+// eslint-disable-next-line import/no-unresolved
 import VipsHeifModule from 'wasm-vips/vips-heif.wasm';
 
 // @ts-expect-error
+// eslint-disable-next-line import/no-unresolved
 import VipsJxlModule from 'wasm-vips/vips-jxl.wasm';
 
 import { getExtensionFromMimeType } from '@mexp/mime';

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -1,6 +1,12 @@
 import Vips from 'wasm-vips';
+
+// @ts-expect-error
 import VipsModule from 'wasm-vips/vips.wasm';
+
+// @ts-expect-error
 import VipsHeifModule from 'wasm-vips/vips-heif.wasm';
+
+// @ts-expect-error
 import VipsJxlModule from 'wasm-vips/vips-jxl.wasm';
 
 import { getExtensionFromMimeType } from '@mexp/mime';

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -1,7 +1,7 @@
-const Vips = require( 'wasm-vips' ) as (
-	config?: Parameters< typeof VipsInstance >[ 0 ]
-) => Promise< NonNullable< typeof VipsInstance > >;
-import type VipsInstance from 'wasm-vips';
+import Vips from 'wasm-vips';
+import VipsModule from 'wasm-vips/vips.wasm';
+import VipsHeifModule from 'wasm-vips/vips-heif.wasm';
+import VipsJxlModule from 'wasm-vips/vips-jxl.wasm';
 
 import { getExtensionFromMimeType } from '@mexp/mime';
 
@@ -19,7 +19,7 @@ type EmscriptenModule = {
 
 let cleanup: () => void;
 
-let vipsInstance: typeof VipsInstance;
+let vipsInstance: typeof Vips;
 
 type ItemId = string;
 
@@ -28,18 +28,23 @@ type ItemId = string;
  *
  * Reuses any existing instance.
  */
-async function getVips(): Promise< typeof VipsInstance > {
+async function getVips(): Promise< typeof Vips > {
 	if ( vipsInstance ) {
 		return vipsInstance;
 	}
 
-	const mainBlobUrl = URL.createObjectURL(
-		await ( await fetch( `${ VIPS_CDN_URL }/vips.js` ) ).blob()
-	);
-
 	vipsInstance = await Vips( {
-		locateFile: ( fileName: string ) => `${ VIPS_CDN_URL }/${ fileName }`,
-		mainScriptUrlOrBlob: mainBlobUrl,
+		locateFile: ( fileName: string ) => {
+			if ( fileName.endsWith( 'vips.wasm' ) ) {
+				fileName = VipsModule;
+			} else if ( fileName.endsWith( 'vips-heif.wasm' ) ) {
+				fileName = VipsHeifModule;
+			} else if ( fileName.endsWith( 'vips-jxl.wasm' ) ) {
+				fileName = VipsJxlModule;
+			}
+
+			return self.location.origin + fileName;
+		},
 		preRun: ( module: EmscriptenModule ) => {
 			// https://github.com/kleisauke/wasm-vips/issues/13#issuecomment-1073246828
 			module.setAutoDeleteLater( true );

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -26,6 +26,12 @@ type EmscriptenModule = {
 	setDelayFunction: ( fn: ( fn: () => void ) => void ) => void;
 };
 
+let location = '';
+
+export function setLocation( newLocation: string ) {
+	location = newLocation;
+}
+
 let cleanup: () => void;
 
 let vipsInstance: typeof Vips;
@@ -52,7 +58,11 @@ async function getVips(): Promise< typeof Vips > {
 				fileName = VipsJxlModule;
 			}
 
-			return self.location.origin + fileName;
+			// fileName is a blob:<...> URL.
+			// Only get the path name and append it to the provided location.
+			return (
+				location + new URL( fileName.replace( 'blob:', '' ) ).pathname
+			);
 		},
 		preRun: ( module: EmscriptenModule ) => {
 			// https://github.com/kleisauke/wasm-vips/issues/13#issuecomment-1073246828

--- a/patches/wasm-vips+0.0.9.patch
+++ b/patches/wasm-vips+0.0.9.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/wasm-vips/package.json b/node_modules/wasm-vips/package.json
+index ed69597..22d63c0 100644
+--- a/node_modules/wasm-vips/package.json
++++ b/node_modules/wasm-vips/package.json
+@@ -25,7 +25,10 @@
+       },
+       "default": "./lib/vips.js"
+     },
+-    "./versions": "./versions.json"
++    "./versions": "./versions.json",
++    "./vips.wasm": "./lib/vips.wasm",
++    "./vips-heif.wasm": "./lib/vips-heif.wasm",
++    "./vips-jxl.wasm": "./lib/vips-jxl.wasm"
+   },
+   "main": "lib/vips-node.js",
+   "browser": "lib/vips.js",

--- a/tests/js/wasm-stub.js
+++ b/tests/js/wasm-stub.js
@@ -1,0 +1,7 @@
+module.exports = {
+	process() {
+		return {
+			code: 'module.exports = ""',
+		};
+	},
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const { resolve, dirname, basename } = require( 'node:path' );
-const { readFileSync } = require( 'node:fs' );
 
 const { DefinePlugin } = require( 'webpack' );
 const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,7 +103,6 @@ module.exports = {
 				generator: {
 					// Use [contenthash:8] to help with cache busting.
 					filename: '[name].[contenthash:8].wasm',
-					publicPath: '/wp-content/plugins/media-experiments/build/',
 				},
 			},
 			...defaultConfig.module.rules.slice( 1 ),


### PR DESCRIPTION
Load wasm-vips locally instead of from a CDN, enabling its features
to work offline.