### PR TITLE
Remove WebKit workaround for wasm-vips

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -77,9 +77,7 @@ const config = defineConfig( {
 		},
 		{
 			name: 'webkit',
-			use: {
-				...devices[ 'Desktop Safari' ],
-			},
+			use: { ...devices[ 'Desktop Safari' ] },
 		},
 		{
 			name: 'firefox',

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -79,14 +79,6 @@ const config = defineConfig( {
 			name: 'webkit',
 			use: {
 				...devices[ 'Desktop Safari' ],
-				launchOptions: {
-					env: {
-						...process.env,
-						// https://bugs.webkit.org/show_bug.cgi?id=276953
-						// eslint-disable-next-line camelcase
-						JSC_webAssemblyLLIntTiersUpToBBQ: 0,
-					},
-				},
 			},
 		},
 		{


### PR DESCRIPTION
This is no longer needed after PR #665.

Resolves: #611.