### PR TITLE
Allow silent cancellation

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -710,24 +710,28 @@ function filter_rest_index( WP_REST_Response $response ): WP_REST_Response {
 /**
  * Returns the attachment's original file name.
  *
+ * Strips any "-original" or "-scaled" suffix from the file name.
+ *
  * @param array $post Post data.
  * @return string|null Attachment file name.
  * @phpstan-param array{id: int} $post
  */
 function rest_get_attachment_filename( array $post ): ?string {
-	$path = wp_get_original_image_path( $post['id'] );
-
-	if ( $path ) {
-		return basename( $path );
-	}
-
 	$path = get_attached_file( $post['id'] );
 
-	if ( $path ) {
-		return basename( $path );
+	if ( ! $path ) {
+		return null;
 	}
 
-	return null;
+	$basename = strtolower( pathinfo( $path, PATHINFO_FILENAME ) );
+	$ext      = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+
+	$suffix = '-scaled';
+	if ( str_ends_with( $basename, $suffix ) ) {
+		$basename = substr( $basename, 0, - strlen( $suffix ) );
+	}
+
+	return "$basename.$ext";
 }
 
 /**

--- a/packages/editor/src/block-media-panel/upload-requests/controls.tsx
+++ b/packages/editor/src/block-media-panel/upload-requests/controls.tsx
@@ -197,7 +197,7 @@ export function UploadRequestControls( props: UploadRequestControlsProps ) {
 		try {
 			await createNewUploadRequest();
 			void openModal( 'media-experiments/upload-request' );
-		} catch ( err ) {
+		} catch {
 			void createErrorNotice(
 				__(
 					'Could not start upload process. Please try again.',

--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -110,7 +110,7 @@ export function start( message: string ): undefined | ( () => void ) {
 		// https://github.com/facebook/react/issues/4216
 		try {
 			throw Error( `${ message } | ${ elapsed } ms` );
-		} catch ( x ) {
+		} catch {
 			// Do nothing.
 		}
 	};
@@ -213,7 +213,7 @@ function _log( message: string, logFunc: typeof console.log = console.log ) {
 	// https://github.com/facebook/react/issues/4216
 	try {
 		throw Error( message );
-	} catch ( x ) {
+	} catch {
 		// Do nothing.
 	}
 

--- a/packages/media-recording/src/store/actions.ts
+++ b/packages/media-recording/src/store/actions.ts
@@ -196,7 +196,7 @@ export function updateMediaDevices() {
 					// remove these devices from the list.
 					.filter( ( device ) => device.label ),
 			} );
-		} catch ( err ) {
+		} catch {
 			// Do nothing for now.
 		}
 	};

--- a/packages/media-recording/src/store/resolvers.ts
+++ b/packages/media-recording/src/store/resolvers.ts
@@ -31,7 +31,7 @@ export function getDevices() {
 					// remove these devices from the list.
 					.filter( ( device ) => device.label ),
 			} );
-		} catch ( err ) {
+		} catch {
 			// Do nothing for now.
 		}
 	};
@@ -210,7 +210,7 @@ export function getMediaStream() {
 
 					try {
 						await selfieSegmentation.send( { image: video } );
-					} catch ( e ) {
+					} catch {
 						// We can't do much about the WASM memory issue.
 					}
 

--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -730,7 +730,7 @@ export function addPosterForItem( id: QueueItemId ) {
 					},
 				} );
 			}
-		} catch ( err ) {
+		} catch {
 			// Do not throw error. Could be a simple error such as video playback not working in tests.
 
 			dispatch.finishOperation( id, {} );
@@ -1067,7 +1067,7 @@ export function uploadPoster( id: QueueItemId ) {
 					abortController,
 					operations,
 				} );
-			} catch ( err ) {
+			} catch {
 				// TODO: Debug & catch & throw.
 			}
 		}
@@ -2136,7 +2136,7 @@ export function generateMetadata( id: QueueItemId ) {
 			try {
 				additionalData.mexp_dominant_color =
 					await dominantColorWorker.getDominantColor( stillUrl );
-			} catch ( err ) {
+			} catch {
 				// No big deal if this fails, we can still continue uploading.
 				// TODO: Debug & catch & throw.
 			}
@@ -2150,7 +2150,7 @@ export function generateMetadata( id: QueueItemId ) {
 			try {
 				additionalData.mexp_has_transparency =
 					await vipsHasTransparency( stillUrl );
-			} catch ( err ) {
+			} catch {
 				// No big deal if this fails, we can still continue uploading.
 				// TODO: Debug & catch & throw.
 			}
@@ -2166,7 +2166,7 @@ export function generateMetadata( id: QueueItemId ) {
 			try {
 				additionalData.mexp_blurhash =
 					await blurhashWorker.getBlurHash( stillUrl );
-			} catch ( err ) {
+			} catch {
 				// No big deal if this fails, we can still continue uploading.
 				// TODO: Debug & catch & throw.
 			}

--- a/packages/upload-media/src/store/test/actions.ts
+++ b/packages/upload-media/src/store/test/actions.ts
@@ -303,7 +303,9 @@ describe( 'actions', () => {
 			expect( registry.select( uploadStore ).getItems() ).toHaveLength(
 				0
 			);
-			expect( onError ).toHaveBeenCalled();
+
+			// Manual cancellation should not trigger the callback to avoid an unnecessary snackbar notice.
+			expect( onError ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should do nothing for an invalid attachment ID', async () => {

--- a/packages/upload-media/src/utils.ts
+++ b/packages/upload-media/src/utils.ts
@@ -127,7 +127,7 @@ export async function fetchFile( url: string, nameOverride?: string ) {
 	if ( ! guessedMimeType ) {
 		throw new UploadError( {
 			code: 'FETCH_REMOTE_FILE_ERROR',
-			message: 'File could not be uploaded',
+			message: 'File could not be downloaded',
 			file,
 		} );
 	}

--- a/packages/upload-media/src/utils.ts
+++ b/packages/upload-media/src/utils.ts
@@ -124,7 +124,7 @@ export async function fetchFile( url: string, nameOverride?: string ) {
 
 	const file = new File( [ blob ], name, { type } );
 
-	if ( ! guessedMimeType ) {
+	if ( ! type ) {
 		throw new UploadError( {
 			code: 'FETCH_REMOTE_FILE_ERROR',
 			message: 'File could not be downloaded',

--- a/tests/e2e/specs/images/optimizing.spec.ts
+++ b/tests/e2e/specs/images/optimizing.spec.ts
@@ -404,7 +404,7 @@ test.describe( 'Images', () => {
 				.filter( {
 					hasText: 'File upload was cancelled',
 				} )
-		).toBeVisible();
+		).toBeHidden();
 
 		await expect( settingsPanel ).toHaveText( /Mime type: image\/png/ );
 

--- a/tests/phpunit/tests/Plugin.php
+++ b/tests/phpunit/tests/Plugin.php
@@ -502,6 +502,24 @@ HTML;
 	}
 
 	/**
+	 * @covers \MediaExperiments\rest_get_attachment_filename
+	 */
+	public function test_rest_get_attachment_filename_removes_suffix() {
+		$attachment_id = self::factory()->attachment->create_object(
+			self::$image_file,
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_excerpt'   => 'A sample caption',
+			)
+		);
+
+		update_post_meta( $attachment_id, '_wp_attached_file', 'canola-scaled.jpg' );
+
+		$this->assertSame( 'canola.jpg', rest_get_attachment_filename( [ 'id' => $attachment_id ] ) );
+	}
+
+	/**
 	 * @covers \MediaExperiments\rest_get_attachment_blurhash
 	 */
 	public function test_rest_get_attachment_blurhash() {


### PR DESCRIPTION
Also fixes an issue with the [`mexp_filename` REST field](https://github.com/swissspidy/media-experiments/commit/26e591cce4eda1e7477ed6301c7182d3391d6efa) 

- Remove potential "-scaled" suffix added by WP
- Do not use original image's file name (which could be a HEIC or JXL or so), but the "full" version's name, which has the mime type you would expect as it matches the one from `source_url`, which is the one used for compressing an existing image

Tested by trying to optimize an existing image in the editor which was originally a JXL. (Maybe should add an e2e test for this..?)

Fixes #646