### PR TITLE
Create workers only on-demand

### DIFF
--- a/packages/editor/src/block-media-panel/generate-caption.tsx
+++ b/packages/editor/src/block-media-panel/generate-caption.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createWorkerFactory } from '@shopify/web-worker';
+import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
 
 /**
  * WordPress dependencies
@@ -20,11 +20,22 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { PREFERENCES_NAME } from '../constants';
 import { ReactComponent as PhotoSpark } from '../icons/photo-spark.svg';
 
-const createAiWorker = createWorkerFactory(
-	() => import( /* webpackChunkName: 'ai' */ '@mexp/ai' )
-);
+let aiWorker:
+	| ReturnType< WorkerCreator< typeof import('@mexp/ai') > >
+	| undefined;
 
-const aiWorker = createAiWorker();
+function getAiWorker() {
+	if ( aiWorker !== undefined ) {
+		return aiWorker;
+	}
+
+	const createWorker = createWorkerFactory(
+		() => import( /* webpackChunkName: 'ai' */ '@mexp/ai' )
+	);
+	aiWorker = createWorker();
+
+	return aiWorker;
+}
 
 interface GenerateCaptionsProps {
 	url?: string;
@@ -60,7 +71,7 @@ export function GenerateCaptions( {
 				setCaptionInProgress( true );
 
 				try {
-					const result = await aiWorker.generateCaption(
+					const result = await getAiWorker().generateCaption(
 						url,
 						'<CAPTION>'
 					);
@@ -89,7 +100,7 @@ export function GenerateCaptions( {
 				setAltInProgress( true );
 
 				try {
-					const result = await aiWorker.generateCaption(
+					const result = await getAiWorker().generateCaption(
 						url,
 						'<DETAILED_CAPTION>'
 					);

--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { v4 as uuidv4 } from 'uuid';
-import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
 
 /**
  * WordPress dependencies
@@ -22,6 +21,7 @@ import {
 	canProcessWithFFmpeg,
 	cloneFile,
 	convertBlobToFile,
+	createWorkerGetter,
 	fetchFile,
 	getFileBasename,
 	getFileExtension,
@@ -84,59 +84,20 @@ import type { cancelItem } from './actions';
 
 type WPDataRegistry = ReturnType< typeof createRegistry >;
 
-let dominantColorWorker:
-	| ReturnType< WorkerCreator< typeof import('./workers/dominant-color') > >
-	| undefined;
+const getDominantColorWorker = createWorkerGetter(
+	() =>
+		import(
+			/* webpackChunkName: 'dominant-color' */ './workers/dominant-color'
+		)
+);
 
-function getDominantColorWorker() {
-	if ( dominantColorWorker !== undefined ) {
-		return dominantColorWorker;
-	}
+const getBlurhashWorker = createWorkerGetter(
+	() => import( /* webpackChunkName: 'blurhash' */ './workers/blurhash' )
+);
 
-	const createWorker = createWorkerFactory(
-		() =>
-			import(
-				/* webpackChunkName: 'dominant-color' */ './workers/dominant-color'
-			)
-	);
-	dominantColorWorker = createWorker();
-
-	return dominantColorWorker;
-}
-
-let blurhashWorker:
-	| ReturnType< WorkerCreator< typeof import('./workers/blurhash') > >
-	| undefined;
-
-function getBlurhashWorker() {
-	if ( blurhashWorker !== undefined ) {
-		return blurhashWorker;
-	}
-
-	const createWorker = createWorkerFactory(
-		() => import( /* webpackChunkName: 'blurhash' */ './workers/blurhash' )
-	);
-	blurhashWorker = createWorker();
-
-	return blurhashWorker;
-}
-
-let aiWorker:
-	| ReturnType< WorkerCreator< typeof import('@mexp/ai') > >
-	| undefined;
-
-function getAiWorker() {
-	if ( aiWorker !== undefined ) {
-		return aiWorker;
-	}
-
-	const createWorker = createWorkerFactory(
-		() => import( /* webpackChunkName: 'ai' */ '@mexp/ai' )
-	);
-	aiWorker = createWorker();
-
-	return aiWorker;
-}
+const getAiWorker = createWorkerGetter(
+	() => import( /* webpackChunkName: 'ai' */ '@mexp/ai' )
+);
 
 // Safari does not currently support WebP in HTMLCanvasElement.toBlob()
 // See https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob

--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { v4 as uuidv4 } from 'uuid';
+import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
 
 /**
  * WordPress dependencies
@@ -21,7 +22,6 @@ import {
 	canProcessWithFFmpeg,
 	cloneFile,
 	convertBlobToFile,
-	createWorkerGetter,
 	fetchFile,
 	getFileBasename,
 	getFileExtension,
@@ -84,20 +84,59 @@ import type { cancelItem } from './actions';
 
 type WPDataRegistry = ReturnType< typeof createRegistry >;
 
-const getDominantColorWorker = createWorkerGetter(
-	() =>
-		import(
-			/* webpackChunkName: 'dominant-color' */ './workers/dominant-color'
-		)
-);
+let dominantColorWorker:
+	| ReturnType< WorkerCreator< typeof import('./workers/dominant-color') > >
+	| undefined;
 
-const getBlurhashWorker = createWorkerGetter(
-	() => import( /* webpackChunkName: 'blurhash' */ './workers/blurhash' )
-);
+function getDominantColorWorker() {
+	if ( dominantColorWorker !== undefined ) {
+		return dominantColorWorker;
+	}
 
-const getAiWorker = createWorkerGetter(
-	() => import( /* webpackChunkName: 'ai' */ '@mexp/ai' )
-);
+	const createWorker = createWorkerFactory(
+		() =>
+			import(
+				/* webpackChunkName: 'dominant-color' */ './workers/dominant-color'
+			)
+	);
+	dominantColorWorker = createWorker();
+
+	return dominantColorWorker;
+}
+
+let blurhashWorker:
+	| ReturnType< WorkerCreator< typeof import('./workers/blurhash') > >
+	| undefined;
+
+function getBlurhashWorker() {
+	if ( blurhashWorker !== undefined ) {
+		return blurhashWorker;
+	}
+
+	const createWorker = createWorkerFactory(
+		() => import( /* webpackChunkName: 'blurhash' */ './workers/blurhash' )
+	);
+	blurhashWorker = createWorker();
+
+	return blurhashWorker;
+}
+
+let aiWorker:
+	| ReturnType< WorkerCreator< typeof import('@mexp/ai') > >
+	| undefined;
+
+function getAiWorker() {
+	if ( aiWorker !== undefined ) {
+		return aiWorker;
+	}
+
+	const createWorker = createWorkerFactory(
+		() => import( /* webpackChunkName: 'ai' */ '@mexp/ai' )
+	);
+	aiWorker = createWorker();
+
+	return aiWorker;
+}
 
 // Safari does not currently support WebP in HTMLCanvasElement.toBlob()
 // See https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob

--- a/packages/upload-media/src/store/utils/canvas.ts
+++ b/packages/upload-media/src/store/utils/canvas.ts
@@ -1,13 +1,31 @@
 /**
+ * External dependencies
+ */
+import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
+
+/**
  * Internal dependencies
  */
 import { ImageFile } from '../../image-file';
-import { createWorkerGetter, getFileBasename } from '../../utils';
+import { getFileBasename } from '../../utils';
 import type { ImageSizeCrop } from '../types';
 
-const getCanvasWorker = createWorkerGetter(
-	() => import( /* webpackChunkName: 'canvas' */ '../workers/canvas' )
-);
+let canvasWorker:
+	| ReturnType< WorkerCreator< typeof import('../workers/canvas') > >
+	| undefined;
+
+function getCanvasWorker() {
+	if ( canvasWorker !== undefined ) {
+		return canvasWorker;
+	}
+
+	const createWorker = createWorkerFactory(
+		() => import( /* webpackChunkName: 'canvas' */ '../workers/canvas' )
+	);
+	canvasWorker = createWorker();
+
+	return canvasWorker;
+}
 
 export async function compressImage( file: File, quality = 0.82 ) {
 	return new File(

--- a/packages/upload-media/src/store/utils/canvas.ts
+++ b/packages/upload-media/src/store/utils/canvas.ts
@@ -1,31 +1,13 @@
 /**
- * External dependencies
- */
-import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
-
-/**
  * Internal dependencies
  */
 import { ImageFile } from '../../image-file';
-import { getFileBasename } from '../../utils';
+import { createWorkerGetter, getFileBasename } from '../../utils';
 import type { ImageSizeCrop } from '../types';
 
-let canvasWorker:
-	| ReturnType< WorkerCreator< typeof import('../workers/canvas') > >
-	| undefined;
-
-function getCanvasWorker() {
-	if ( canvasWorker !== undefined ) {
-		return canvasWorker;
-	}
-
-	const createWorker = createWorkerFactory(
-		() => import( /* webpackChunkName: 'canvas' */ '../workers/canvas' )
-	);
-	canvasWorker = createWorker();
-
-	return canvasWorker;
-}
+const getCanvasWorker = createWorkerGetter(
+	() => import( /* webpackChunkName: 'canvas' */ '../workers/canvas' )
+);
 
 export async function compressImage( file: File, quality = 0.82 ) {
 	return new File(

--- a/packages/upload-media/src/store/utils/heif.ts
+++ b/packages/upload-media/src/store/utils/heif.ts
@@ -1,29 +1,11 @@
 /**
- * External dependencies
- */
-import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
-
-/**
  * Internal dependencies
  */
-import { getFileBasename } from '../../utils';
+import { createWorkerGetter, getFileBasename } from '../../utils';
 
-let heifWorker:
-	| ReturnType< WorkerCreator< typeof import('@mexp/heif') > >
-	| undefined;
-
-function getHeifWorker() {
-	if ( heifWorker !== undefined ) {
-		return heifWorker;
-	}
-
-	const createWorker = createWorkerFactory(
-		() => import( /* webpackChunkName: 'heif' */ '@mexp/heif' )
-	);
-	heifWorker = createWorker();
-
-	return heifWorker;
-}
+const getHeifWorker = createWorkerGetter(
+	() => import( /* webpackChunkName: 'heif' */ '@mexp/heif' )
+);
 
 /**
  * Creates a Blob from a given ArrayBuffer.

--- a/packages/upload-media/src/store/utils/heif.ts
+++ b/packages/upload-media/src/store/utils/heif.ts
@@ -1,18 +1,29 @@
 /**
  * External dependencies
  */
-import { createWorkerFactory } from '@shopify/web-worker';
+import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
 
 /**
  * Internal dependencies
  */
 import { getFileBasename } from '../../utils';
 
-const createHeifWorker = createWorkerFactory(
-	() => import( /* webpackChunkName: 'heif' */ '@mexp/heif' )
-);
+let heifWorker:
+	| ReturnType< WorkerCreator< typeof import('@mexp/heif') > >
+	| undefined;
 
-const heifWorker = createHeifWorker();
+function getHeifWorker() {
+	if ( heifWorker !== undefined ) {
+		return heifWorker;
+	}
+
+	const createWorker = createWorkerFactory(
+		() => import( /* webpackChunkName: 'heif' */ '@mexp/heif' )
+	);
+	heifWorker = createWorker();
+
+	return heifWorker;
+}
 
 /**
  * Creates a Blob from a given ArrayBuffer.
@@ -54,7 +65,7 @@ export async function transcodeHeifImage(
 	type: 'image/jpeg' | 'image/png' | 'image/webp' = 'image/jpeg',
 	quality = 0.82
 ) {
-	const { buffer, width, height } = await heifWorker.transcodeHeifImage(
+	const { buffer, width, height } = await getHeifWorker().transcodeHeifImage(
 		await file.arrayBuffer()
 	);
 

--- a/packages/upload-media/src/store/utils/heif.ts
+++ b/packages/upload-media/src/store/utils/heif.ts
@@ -1,11 +1,29 @@
 /**
+ * External dependencies
+ */
+import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
+
+/**
  * Internal dependencies
  */
-import { createWorkerGetter, getFileBasename } from '../../utils';
+import { getFileBasename } from '../../utils';
 
-const getHeifWorker = createWorkerGetter(
-	() => import( /* webpackChunkName: 'heif' */ '@mexp/heif' )
-);
+let heifWorker:
+	| ReturnType< WorkerCreator< typeof import('@mexp/heif') > >
+	| undefined;
+
+function getHeifWorker() {
+	if ( heifWorker !== undefined ) {
+		return heifWorker;
+	}
+
+	const createWorker = createWorkerFactory(
+		() => import( /* webpackChunkName: 'heif' */ '@mexp/heif' )
+	);
+	heifWorker = createWorker();
+
+	return heifWorker;
+}
 
 /**
  * Creates a Blob from a given ArrayBuffer.

--- a/packages/upload-media/src/store/utils/vips.ts
+++ b/packages/upload-media/src/store/utils/vips.ts
@@ -1,13 +1,31 @@
 /**
+ * External dependencies
+ */
+import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
+
+/**
  * Internal dependencies
  */
 import { ImageFile } from '../../image-file';
-import { createWorkerGetter, getFileBasename } from '../../utils';
+import { getFileBasename } from '../../utils';
 import type { ImageSizeCrop, QueueItemId } from '../types';
 
-const getVipsWorker = createWorkerGetter(
-	() => import( /* webpackChunkName: 'vips' */ '@mexp/vips' )
-);
+let vipsWorker:
+	| ReturnType< WorkerCreator< typeof import('@mexp/vips') > >
+	| undefined;
+
+function getVipsWorker() {
+	if ( vipsWorker !== undefined ) {
+		return vipsWorker;
+	}
+
+	const createWorker = createWorkerFactory(
+		() => import( /* webpackChunkName: 'vips' */ '@mexp/vips' )
+	);
+	vipsWorker = createWorker();
+
+	return vipsWorker;
+}
 
 export async function vipsConvertImageFormat(
 	id: QueueItemId,

--- a/packages/upload-media/src/store/utils/vips.ts
+++ b/packages/upload-media/src/store/utils/vips.ts
@@ -1,31 +1,13 @@
 /**
- * External dependencies
- */
-import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
-
-/**
  * Internal dependencies
  */
 import { ImageFile } from '../../image-file';
-import { getFileBasename } from '../../utils';
+import { createWorkerGetter, getFileBasename } from '../../utils';
 import type { ImageSizeCrop, QueueItemId } from '../types';
 
-let vipsWorker:
-	| ReturnType< WorkerCreator< typeof import('@mexp/vips') > >
-	| undefined;
-
-function getVipsWorker() {
-	if ( vipsWorker !== undefined ) {
-		return vipsWorker;
-	}
-
-	const createWorker = createWorkerFactory(
-		() => import( /* webpackChunkName: 'vips' */ '@mexp/vips' )
-	);
-	vipsWorker = createWorker();
-
-	return vipsWorker;
-}
+const getVipsWorker = createWorkerGetter(
+	() => import( /* webpackChunkName: 'vips' */ '@mexp/vips' )
+);
 
 export async function vipsConvertImageFormat(
 	id: QueueItemId,

--- a/packages/upload-media/src/utils.ts
+++ b/packages/upload-media/src/utils.ts
@@ -8,6 +8,7 @@ import mime from 'mime/lite';
  */
 import { getFilename } from '@wordpress/url';
 import { __, _x, sprintf } from '@wordpress/i18n';
+import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
 
 /**
  * Internal dependencies
@@ -457,4 +458,21 @@ export function isImageTypeSupported(
 		'image/tiff',
 		'image/webp',
 	].includes( type );
+}
+
+export function createWorkerGetter< TModule >(
+	importer: () => Promise< TModule >
+) {
+	let worker: ReturnType< WorkerCreator< TModule > > | undefined;
+
+	return function getWorker(): ReturnType< WorkerCreator< TModule > > {
+		if ( worker !== undefined ) {
+			return worker;
+		}
+
+		const createWorker = createWorkerFactory( importer );
+		worker = createWorker();
+
+		return worker;
+	};
 }

--- a/packages/upload-media/src/utils.ts
+++ b/packages/upload-media/src/utils.ts
@@ -8,7 +8,6 @@ import mime from 'mime/lite';
  */
 import { getFilename } from '@wordpress/url';
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { createWorkerFactory, type WorkerCreator } from '@shopify/web-worker';
 
 /**
  * Internal dependencies
@@ -458,21 +457,4 @@ export function isImageTypeSupported(
 		'image/tiff',
 		'image/webp',
 	].includes( type );
-}
-
-export function createWorkerGetter< TModule >(
-	importer: () => Promise< TModule >
-) {
-	let worker: ReturnType< WorkerCreator< TModule > > | undefined;
-
-	return function getWorker(): ReturnType< WorkerCreator< TModule > > {
-		if ( worker !== undefined ) {
-			return worker;
-		}
-
-		const createWorker = createWorkerFactory( importer );
-		worker = createWorker();
-
-		return worker;
-	};
 }


### PR DESCRIPTION
Avoids unnecessarily importing workers right away, but only when needed.

This is a follow-up to #753, where the scripts got way bigger so some tests fail due to timeouts.